### PR TITLE
Update Cargo.toml

### DIFF
--- a/pic32-hal/Cargo.toml
+++ b/pic32-hal/Cargo.toml
@@ -23,7 +23,7 @@ mips-mcu = "0.3.0"
 mips-rt = "0.3.0"
 critical-section = "1.0.0"
 usb-device = { version = "0.2.9", optional = true }
-enumflags2 = "0.7.5"
+enumflags2 = "0.7.7"
 
 [dependencies.pic32mx2xx]
 version = "0.7.0"


### PR DESCRIPTION
Updates dependency to the patch version of 0.7.7

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0035.html)
[fix](https://github.com/meithecatte/enumflags2/releases/tag/v0.7.7)